### PR TITLE
Accumulate rewards on audit request

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -14,6 +14,7 @@
 #define AUDIT "evnAudit"
 #define AUDIT_ASSIGNMENT "evnAuditAssignment"
 #define AUDIT_SUCCESS "evnAuditSuccess"
+#define AUDIT_FAILED "evnAuditFailed"
 #define REWARD "evnReward"
 
 #define FORMAT_HEX "hex"
@@ -49,8 +50,10 @@ const uint32_t REDEEM_STATE_VAL_SIZE = 59;
 const uint32_t MOMENT_SEED_VAL_SIZE = 40;
 const uint32_t AMOUNT_BUF_SIZE = 48;
 const uint32_t HASH_SIZE = 32;
-const uint32_t HOST_AUDIT_INFO_OFFSET = 77;
-const uint32_t HOST_REWARD_INFO_OFFSET = 105;
+const uint32_t HOST_AUDIT_IDX_OFFSET = 77;
+const uint32_t HOST_AUDITOR_OFFSET = 85;
+const uint32_t HOST_REWARD_IDX_OFFSET = 105;
+const uint32_t HOST_ACCUMULATED_AMT_OFFSET = 113;
 const uint32_t INSTANCE_INFO_OFFSET = 7;
 const uint32_t INSTANCE_SIZE_LEN = 60;
 const uint32_t LOCATION_LEN = 10;

--- a/src/evernode.c
+++ b/src/evernode.c
@@ -400,9 +400,11 @@ int64_t hook(int64_t reserved)
                             int64_t cur_acc_amount = INT64_FROM_BUF(cur_acc_amount_ptr);
 
                             // If last audit hasn't been rewarded it should be a audit failure.
-                            // Then add accumulated amount to the pool.
+                            // Then if accumulated amount is > 0 add accumulated amount to the pool.
                             uint64_t audit_assigned_moment_start_idx = UINT64_FROM_BUF(&host_addr_buf[HOST_AUDIT_IDX_OFFSET]);
-                            if ((cur_moment_start_idx > audit_assigned_moment_start_idx) && (audit_assigned_moment_start_idx > UINT64_FROM_BUF(&host_addr_buf[HOST_REWARD_IDX_OFFSET])))
+                            if ((cur_moment_start_idx > audit_assigned_moment_start_idx) &&
+                                (cur_acc_amount > 0) &&
+                                (audit_assigned_moment_start_idx > UINT64_FROM_BUF(&host_addr_buf[HOST_REWARD_IDX_OFFSET])))
                             {
                                 ADD_TO_REWARD_POOL(cur_acc_amount);
                                 cur_acc_amount = 0;

--- a/src/evernode.c
+++ b/src/evernode.c
@@ -549,7 +549,7 @@ int64_t hook(int64_t reserved)
                     int64_t reward_amount = INT64_FROM_BUF(acc_amount_ptr);
 
                     // If reward amount is zero, means accumulated amount is already made zero.
-                    // Since above host already rewarded check failed it means accumulated amout is empied by an audit failure.
+                    // Since host already rewarded check failed in line 544 it means accumulated amout is empied by an audit failure.
                     if (reward_amount == 0)
                         rollback(SBUF("Evernode: An audit for this host has been already failed within this moment."), 1);
 

--- a/src/evernode.h
+++ b/src/evernode.h
@@ -182,6 +182,21 @@ const uint8_t evr_currency[20] = GET_TOKEN_CURRENCY(EVR_TOKEN);
             host_count = UINT32_FROM_BUF(host_count_buf);                      \
     }
 
+// Adds the given amount to the reward pool.
+#define ADD_TO_REWARD_POOL(float_amount)                                         \
+    {                                                                            \
+        /* Take the current reward pool amount from the config. */               \
+        uint8_t reward_pool_buf[8] = {0};                                        \
+        int64_t reward_pool = 0;                                                 \
+        if (state(SBUF(reward_pool_buf), SBUF(STK_REWARD_POOL)) != DOESNT_EXIST) \
+            reward_pool = INT64_FROM_BUF(reward_pool_buf);                       \
+        reward_pool = float_sum(reward_pool, float_amount);                      \
+        /* Update the last accumulated moment state. */                          \
+        INT64_TO_BUF(reward_pool_buf, reward_pool);                              \
+        if (state_set(SBUF(reward_pool_buf), SBUF(STK_REWARD_POOL)) < 0)         \
+            rollback(SBUF("Evernode: Could not update the reward pool."), 1);    \
+    }
+
 // We need to dump the iou amount into a buffer.
 // by supplying -1 as the fieldcode we tell float_sto not to prefix an actual STO header on the field.
 #define SET_AMOUNT_OUT_GUARD(amt_out, token, issuer, amount, n)                   \

--- a/src/statekeys.h
+++ b/src/statekeys.h
@@ -19,6 +19,14 @@ const uint8_t STK_MOMENT_BASE_IDX[32] = {'E', 'V', 'R', 52, 0, 0, 0, 0, 0, 0, 0,
 // value 53 is in decimal. Its converted to 35 in hex.
 const uint8_t STK_MOMENT_SEED[32] = {'E', 'V', 'R', 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
+// Last moment start index where rewards have been accumulated
+// value 54 is in decimal. Its converted to 36 in hex.
+const uint8_t STK_ACCUMULATED_MOMENT_IDX[32] = {'E', 'V', 'R', 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+// Pool of reward amounts which are received on a audit failure.
+// value 55 is in decimal. Its converted to 37 in hex.
+const uint8_t STK_REWARD_POOL[32] = {'E', 'V', 'R', 55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
 /////////// Repetitive state keys. ///////////
 
 // Host id keys (Host registration entries for id-based lookup). Last 4 bytes will be replaced by host id in runtime.


### PR DESCRIPTION
- Updated accumulated reward amount in first audit request of the every moment
- Keep track of the missed moments
- Add rewards to reward pool on audit failure or audit response hasn't been received
- Introduce new event for audit failed
- Added new states for last accumulated moment and reward pool