### PR TITLE
Host heartbeat and Active host tracking

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -16,6 +16,7 @@
 #define AUDIT_SUCCESS "evnAuditSuccess"
 #define AUDIT_FAILED "evnAuditFailed"
 #define REWARD "evnReward"
+#define RECHARGE "evnRecharge"
 
 #define FORMAT_HEX "hex"
 #define FORMAT_BASE64 "base64"
@@ -41,6 +42,7 @@ const int64_t DEF_REWARD_M = 64;
 const int32_t DEF_REWARD_E = 0;
 const uint16_t DEF_MAX_REWARD = 20;
 const uint16_t DEF_MAX_AUDIT = 5;
+const uint16_t DEF_HOST_HEARTBEAT_FREQ = 1;
 const uint8_t DEF_AUDITOR_ADDR[35] = "rUWDtXPk4gAp8L6dNS51hLArnwFk4bRxky"; // This is a hard coded value, can be changed later.
 
 // Constants
@@ -50,14 +52,25 @@ const uint32_t REDEEM_STATE_VAL_SIZE = 59;
 const uint32_t MOMENT_SEED_VAL_SIZE = 40;
 const uint32_t AMOUNT_BUF_SIZE = 48;
 const uint32_t HASH_SIZE = 32;
-const uint32_t HOST_AUDIT_IDX_OFFSET = 77;
-const uint32_t HOST_AUDITOR_OFFSET = 85;
-const uint32_t HOST_REWARD_IDX_OFFSET = 105;
-const uint32_t HOST_ACCUMULATED_AMT_OFFSET = 113;
-const uint32_t INSTANCE_INFO_OFFSET = 7;
-const uint32_t INSTANCE_SIZE_LEN = 60;
-const uint32_t LOCATION_LEN = 10;
+const uint32_t COUNTRY_CODE_LEN = 2;
+const uint32_t DESCRIPTION_LEN = 26;
 const uint32_t REDEEM_ORIGIN_DATA_LEN = 63;
+
+// State value offsets
+// HOST_ADDR
+const uint32_t HOST_TOKEN_OFFSET = 4;
+const uint32_t HOST_COUNTRY_CODE_OFFSET = 7;
+const uint32_t HOST_CPU_MICROSEC_OFFSET = 9;
+const uint32_t HOST_RAM_MB_OFFSET = 13;
+const uint32_t HOST_DISK_MB_OFFSET = 17;
+const uint32_t HOST_RESERVED_OFFSET = 21;
+const uint32_t HOST_DESCRIPTION_OFFSET = 29;
+const uint32_t HOST_AUDIT_IDX_OFFSET = 55;
+const uint32_t HOST_AUDITOR_OFFSET = 63;
+const uint32_t HOST_REWARD_IDX_OFFSET = 83;
+const uint32_t HOST_ACCUMULATED_AMT_OFFSET = 91;
+const uint32_t HOST_LOCKED_TOKEN_AMT_OFFSET = 99;
+const uint32_t HOST_HEARTBEAT_LEDGER_IDX_OFFSET = 107;
 
 const uint64_t MIN_DROPS = 1;
 const char *empty_ptr = 0;

--- a/src/constants.h
+++ b/src/constants.h
@@ -46,7 +46,7 @@ const uint16_t DEF_HOST_HEARTBEAT_FREQ = 1;
 const uint8_t DEF_AUDITOR_ADDR[35] = "rUWDtXPk4gAp8L6dNS51hLArnwFk4bRxky"; // This is a hard coded value, can be changed later.
 
 // Constants
-const uint32_t HOST_ADDR_VAL_SIZE = 125;
+const uint32_t HOST_ADDR_VAL_SIZE = 115;
 const uint32_t AUDITOR_ADDR_VAL_SIZE = 32;
 const uint32_t REDEEM_STATE_VAL_SIZE = 59;
 const uint32_t MOMENT_SEED_VAL_SIZE = 40;

--- a/src/evernode.c
+++ b/src/evernode.c
@@ -477,7 +477,7 @@ int64_t hook(int64_t reserved)
                     if ((auditor_count > active_host_count) && (pick_idx >= active_host_count))
                         rollback(SBUF("Evernode: No enough hosts to audit for this auditor."), 1);
                     else if ((pick_idx == auditor_count - 1) && (active_host_count % auditor_count > 0))
-                        pick_count = active_host_count % auditor_count;
+                        pick_count = active_host_count % pick_count;
                     // Which is the picking endig host index for this auditor.
                     uint32_t pick_host_to_idx = (pick_host_from_idx + pick_count) % active_host_count;
 

--- a/src/evernode.c
+++ b/src/evernode.c
@@ -118,7 +118,7 @@ int64_t hook(int64_t reserved)
                 int64_t fee = etxn_fee_base(PREPARE_PAYMENT_REDEEM_RESP_SIZE(sizeof(redeem_res), sizeof(redeem_ref), is_redeem_suc));
 
                 uint8_t txn_out[PREPARE_PAYMENT_REDEEM_RESP_SIZE(sizeof(redeem_res), sizeof(redeem_ref), is_redeem_suc)];
-                PREPARE_PAYMENT_REDEEM_RESP_M(txn_out, MIN_DROPS, fee, useraddr_ptr, redeem_res, sizeof(redeem_res), redeem_ref, sizeof(redeem_ref), is_redeem_suc, 121);
+                PREPARE_PAYMENT_REDEEM_RESP_M(txn_out, MIN_DROPS, fee, useraddr_ptr, redeem_res, sizeof(redeem_res), redeem_ref, sizeof(redeem_ref), is_redeem_suc, 10);
 
                 uint8_t emithash[HASH_SIZE];
                 if (emit(SBUF(emithash), SBUF(txn_out)) < 0)
@@ -208,7 +208,7 @@ int64_t hook(int64_t reserved)
 
                     // Finally create the outgoing txn.
                     uint8_t txn_out[PREPARE_PAYMENT_REFUND_ERROR_SIZE];
-                    PREPARE_PAYMENT_REFUND_ERROR_M(txn_out, MIN_DROPS, fee, account_field, txid, 211);
+                    PREPARE_PAYMENT_REFUND_ERROR_M(txn_out, MIN_DROPS, fee, account_field, txid, 10);
 
                     uint8_t emithash[HASH_SIZE];
                     if (emit(SBUF(emithash), SBUF(txn_out)) < 0)
@@ -244,7 +244,7 @@ int64_t hook(int64_t reserved)
 
                     // Finally create the outgoing txn.
                     uint8_t txn_out[PREPARE_PAYMENT_REFUND_SUCCESS_SIZE];
-                    PREPARE_PAYMENT_REFUND_SUCCESS_M(txn_out, amt_out, fee, account_field, txid, refund_ref, 247);
+                    PREPARE_PAYMENT_REFUND_SUCCESS_M(txn_out, amt_out, fee, account_field, txid, refund_ref, 10);
 
                     uint8_t emithash[HASH_SIZE];
                     if (emit(SBUF(emithash), SBUF(txn_out)) < 0)
@@ -535,7 +535,7 @@ int64_t hook(int64_t reserved)
                                 is_picked = i >= pick_host_from_idx || i < pick_host_to_idx;
 
                             if (is_picked)
-                                EMIT_AUDIT_CHECK_GUARDM(cur_moment_start_idx, moment_seed_buf, conf_min_redeem, host_addr_ptr, host_addr_buf, account_field, pick_count, 538);
+                                EMIT_AUDIT_CHECK_GUARDM(cur_moment_start_idx, moment_seed_buf, conf_min_redeem, host_addr_ptr, host_addr_buf, account_field, pick_count, 10);
 
                             if (state_set(SBUF(host_addr_buf), SBUF(STP_HOST_ADDR)) < 0)
                                 rollback(SBUF("Evernode: Could not update audit moment for host_addr."), 1);
@@ -562,7 +562,7 @@ int64_t hook(int64_t reserved)
                             if (state(SBUF(host_addr_buf), SBUF(STP_HOST_ADDR)) == DOESNT_EXIST)
                                 rollback(SBUF("Evernode: Host is not registered."), 1);
 
-                            EMIT_AUDIT_CHECK_GUARDM(cur_moment_start_idx, moment_seed_buf, conf_min_redeem, host_addr_ptr, host_addr_buf, account_field, pick_count, 565);
+                            EMIT_AUDIT_CHECK_GUARDM(cur_moment_start_idx, moment_seed_buf, conf_min_redeem, host_addr_ptr, host_addr_buf, account_field, pick_count, 10);
 
                             if (state_set(SBUF(host_addr_buf), SBUF(STP_HOST_ADDR)) < 0)
                                 rollback(SBUF("Evernode: Could not update audit moment for host_addr."), 1);
@@ -634,7 +634,7 @@ int64_t hook(int64_t reserved)
 
                         // Create the outgoing hosting token txn.
                         uint8_t txn_out[PREPARE_PAYMENT_REWARD_SIZE];
-                        PREPARE_PAYMENT_REWARD_M(txn_out, amt_out, fee, host_addr_ptr, 637);
+                        PREPARE_PAYMENT_REWARD_M(txn_out, amt_out, fee, host_addr_ptr, 10);
 
                         uint8_t emithash[HASH_SIZE];
                         if (emit(SBUF(emithash), SBUF(txn_out)) < 0)
@@ -1037,7 +1037,7 @@ int64_t hook(int64_t reserved)
                 int64_t fee = etxn_fee_base(PREPARE_PAYMENT_REDEEM_SIZE(sizeof(redeem_data), sizeof(origin_data)));
 
                 uint8_t txn_out[PREPARE_PAYMENT_REDEEM_SIZE(sizeof(redeem_data), sizeof(origin_data))];
-                PREPARE_PAYMENT_REDEEM_M(txn_out, MIN_DROPS, fee, issuer_ptr, redeem_data, sizeof(redeem_data), origin_data, sizeof(origin_data), 1040);
+                PREPARE_PAYMENT_REDEEM_M(txn_out, MIN_DROPS, fee, issuer_ptr, redeem_data, sizeof(redeem_data), origin_data, sizeof(origin_data), 10);
 
                 uint8_t emithash[HASH_SIZE];
                 if (emit(SBUF(emithash), SBUF(txn_out)) < 0)
@@ -1149,8 +1149,10 @@ int64_t hook(int64_t reserved)
                 if (IS_FLOAT_ZERO(excess_amount))
                     excess_amount = 0;
 
-                // If transfer amount(amount we have + current recharge amount - max amount) < 0, hook does not have enogh hosting tokens.
-                // If transfer amount > 0, we refund them to the host.
+                // If excess amount(amount we have + current recharge amount - max amount) < 0, hook does not have enough hosting tokens.
+                // If excess amount > 0, we refund them to the host.
+                if (float_compare(excess_amount, 0, COMPARE_LESS) == 1)
+                    rollback(SBUF("Evernode: Recharge amount is less than minimum required hosting token amount."), 1);
                 if (float_compare(excess_amount, 0, COMPARE_GREATER) == 1)
                 {
                     // Send hosting tokens to the host.

--- a/src/evernode.c
+++ b/src/evernode.c
@@ -428,7 +428,8 @@ int64_t hook(int64_t reserved)
 
                         // Take the last audit assigned moment.
                         HOST_ADDR_KEY_GUARD(host_addr, host_count);
-                        // <host_id(4)><hosting_token(3)><instance_size(60)><location(10)><audit_assigned_moment_start_idx(8)><auditor_addr(20)><rewarded_moment_start_idx(8)>
+                        // <host_id(4)><hosting_token(3)><country_code(2)><cpu_microsec(4)><ram_mb(4)><disk_mb(4)><reserved(8)><description(26)><audit_assigned_moment_start_idx(8)>
+                        // <auditor_addr(20)><rewarded_moment_start_idx(8)><accumulated_rewards(8)><locked_token_amont(8)><last_hearbeat_ledger_idx(8)>
                         uint8_t host_addr_buf[HOST_ADDR_VAL_SIZE];
                         if (state(SBUF(host_addr_buf), SBUF(STP_HOST_ADDR)) == DOESNT_EXIST)
                             rollback(SBUF("Evernode: Host is not registered."), 1);

--- a/src/evernode.c
+++ b/src/evernode.c
@@ -476,7 +476,7 @@ int64_t hook(int64_t reserved)
                     if ((pick_idx == auditor_count - 1) && (active_host_count % auditor_count > 0))
                         pick_count = active_host_count % auditor_count;
                     // Which is the picking endig host index for this auditor.
-                    uint32_t pick_host_to_idx = (pick_start_host_idx + pick_count) % active_host_count;
+                    uint32_t pick_host_to_idx = (pick_host_from_idx + pick_count) % active_host_count;
 
                     // Setup the outgoing txns for all checkCreates representing hosts assigned for this auditor.
                     etxn_reserve(pick_count);
@@ -532,7 +532,7 @@ int64_t hook(int64_t reserved)
                                 is_picked = i >= pick_host_from_idx || i < pick_host_to_idx;
 
                             if (is_picked)
-                                EMIT_AUDIT_CHECK_GUARD(cur_moment_start_idx, moment_seed_buf, conf_min_redeem, host_addr_ptr, host_addr_buf, account_field, pick_count);
+                                EMIT_AUDIT_CHECK_GUARD(cur_moment_start_idx, moment_seed_buf, conf_min_redeem, host_addr_ptr, host_addr_buf, account_field, active_host_count);
 
                             if (state_set(SBUF(host_addr_buf), SBUF(STP_HOST_ADDR)) < 0)
                                 rollback(SBUF("Evernode: Could not update audit moment for host_addr."), 1);

--- a/src/evernode.h
+++ b/src/evernode.h
@@ -573,6 +573,15 @@ const uint8_t evr_currency[20] = GET_TOKEN_CURRENCY(EVR_TOKEN);
             is_active = (last_hearbeat_ledger_idx > 0);                                                                                                                \
     }
 
+#define IS_HOST_ACTIVE(is_active, host_addr_buf, cur_ledger_seq)                                                                       \
+    {                                                                                                                                  \
+        uint16_t conf_moment_size;                                                                                                     \
+        GET_CONF_VALUE(conf_moment_size, DEF_MOMENT_SIZE, CONF_MOMENT_SIZE, "Evernode: Could not set default state for moment size."); \
+        uint64_t cur_moment_start_idx;                                                                                                 \
+        GET_MOMENT_START_INDEX_MOMENT_SIZE_GIVEN(cur_moment_start_idx, cur_ledger_seq, conf_moment_size);                              \
+        IS_HOST_ACTIVE_MOMENT_IDX_SIZE_GIVEN(is_active, host_addr_buf, cur_moment_start_idx, conf_moment_size);                        \
+    }
+
 #define EMIT_AUDIT_CHECK_GUARD(cur_moment_start_idx, moment_seed_buf, min_redeem, host_addr, host_addr_buf, to_addr, n) \
     {                                                                                                                   \
         uint8_t *host_token_ptr = &host_addr_buf[HOST_TOKEN_OFFSET];                                                    \
@@ -596,12 +605,4 @@ const uint8_t evr_currency[20] = GET_TOKEN_CURRENCY(EVR_TOKEN);
         COPY_BUF_GUARDM(host_addr_buf, HOST_AUDITOR_OFFSET, to_addr, 0, 20, n, 14);                                     \
     }
 
-#define IS_HOST_ACTIVE(is_active, host_addr_buf, cur_ledger_seq)                                                                       \
-    {                                                                                                                                  \
-        uint16_t conf_moment_size;                                                                                                     \
-        GET_CONF_VALUE(conf_moment_size, DEF_MOMENT_SIZE, CONF_MOMENT_SIZE, "Evernode: Could not set default state for moment size."); \
-        uint64_t cur_moment_start_idx;                                                                                                 \
-        GET_MOMENT_START_INDEX_MOMENT_SIZE_GIVEN(cur_moment_start_idx, cur_ledger_seq, conf_moment_size);                              \
-        IS_HOST_ACTIVE_MOMENT_IDX_SIZE_GIVEN(is_active, host_addr_buf, cur_moment_start_idx, conf_moment_size);                        \
-    }
 #endif

--- a/src/evernode.h
+++ b/src/evernode.h
@@ -230,30 +230,27 @@ const uint8_t evr_currency[20] = GET_TOKEN_CURRENCY(EVR_TOKEN);
     {                                                                                                                                                              \
         ENCODE_FIELDS(buf_out, ARRAY, MEMOS); /*Arr Start*/                                         /* uint32  | size   1 */                                       \
         ENCODE_FIELDS(buf_out, OBJECT, MEMO); /*Obj start*/                                         /* uint32  | size   1 */                                       \
-        _07_XX_ENCODE_STI_VL_COMMON_GUARDM(buf_out, type_ptr, type_len, MEMO_TYPE, n, m + 7);       /* STI_VL  | size   type_len + (type_len <= 192 ? 2 : 3)*/     \
-        _07_XX_ENCODE_STI_VL_COMMON_GUARDM(buf_out, data_ptr, data_len, MEMO_DATA, n, m + 8);       /* STI_VL  | size   data_len + (data_len <= 192 ? 2 : 3)*/     \
-        _07_XX_ENCODE_STI_VL_COMMON_GUARDM(buf_out, format_ptr, format_len, MEMO_FORMAT, n, m + 9); /* STI_VL  | size   format_len + (format_len <= 192 ? 2 : 3)*/ \
+        _07_XX_ENCODE_STI_VL_COMMON_GUARDM(buf_out, type_ptr, type_len, MEMO_TYPE, n, m);           /* STI_VL  | size   type_len + (type_len <= 192 ? 2 : 3)*/     \
+        _07_XX_ENCODE_STI_VL_COMMON_GUARDM(buf_out, data_ptr, data_len, MEMO_DATA, n, m + 1);       /* STI_VL  | size   data_len + (data_len <= 192 ? 2 : 3)*/     \
+        _07_XX_ENCODE_STI_VL_COMMON_GUARDM(buf_out, format_ptr, format_len, MEMO_FORMAT, n, m + 2); /* STI_VL  | size   format_len + (format_len <= 192 ? 2 : 3)*/ \
         ENCODE_FIELDS(buf_out, OBJECT, END); /*Obj end*/                                            /* uint32  | size   1 */                                       \
         ENCODE_FIELDS(buf_out, ARRAY, END); /*Arr End*/                                             /* uint32  | size   1 */                                       \
     }
 
-#define _0F_09_ENCODE_MEMOS_SINGLE(buf_out, type_ptr, type_len, format_ptr, format_len, data_ptr, data_len) \
-    _0F_09_ENCODE_MEMOS_SINGLE_GUARDM(buf_out, type_ptr, type_len, format_ptr, format_len, data_ptr, data_len, 1, 1)
-
-#define _0F_09_ENCODE_MEMOS_DUO(buf_out, type1_ptr, type1_len, format1_ptr, format1_len, data1_ptr, data1_len, type2_ptr, type2_len, format2_ptr, format2_len, data2_ptr, data2_len) \
-    {                                                                                                                                                                                \
-        ENCODE_FIELDS(buf_out, ARRAY, MEMOS); /*Arr Start*/                                        /* uint32  | size   1 */                                                          \
-        ENCODE_FIELDS(buf_out, OBJECT, MEMO); /*Obj start*/                                        /* uint32  | size   1 */                                                          \
-        _07_XX_ENCODE_STI_VL_COMMON_GUARDM(buf_out, type1_ptr, type1_len, MEMO_TYPE, 1, 7);        /* STI_VL  | size   type_len + (type_len <= 192 ? 2 : 3)*/                        \
-        _07_XX_ENCODE_STI_VL_COMMON_GUARDM(buf_out, data1_ptr, data1_len, MEMO_DATA, 1, 8);        /* STI_VL  | size   data_len + (data_len <= 192 ? 2 : 3)*/                        \
-        _07_XX_ENCODE_STI_VL_COMMON_GUARDM(buf_out, format1_ptr, format1_len, MEMO_FORMAT, 1, 9);  /* STI_VL  | size   format_len + (format_len <= 192 ? 2 : 3)*/                    \
-        ENCODE_FIELDS(buf_out, OBJECT, END); /*Obj end*/                                           /* uint32  | size   1 */                                                          \
-        ENCODE_FIELDS(buf_out, OBJECT, MEMO); /*Obj start*/                                        /* uint32  | size   1 */                                                          \
-        _07_XX_ENCODE_STI_VL_COMMON_GUARDM(buf_out, type2_ptr, type2_len, MEMO_TYPE, 1, 10);       /* STI_VL  | size   type_len + (type_len <= 192 ? 2 : 3)*/                        \
-        _07_XX_ENCODE_STI_VL_COMMON_GUARDM(buf_out, data2_ptr, data2_len, MEMO_DATA, 1, 11);       /* STI_VL  | size   data_len + (data_len <= 192 ? 2 : 3)*/                        \
-        _07_XX_ENCODE_STI_VL_COMMON_GUARDM(buf_out, format2_ptr, format2_len, MEMO_FORMAT, 1, 12); /* STI_VL  | size   format_len + (format_len <= 192 ? 2 : 3)*/                    \
-        ENCODE_FIELDS(buf_out, OBJECT, END); /*Obj end*/                                           /* uint32  | size   1 */                                                          \
-        ENCODE_FIELDS(buf_out, ARRAY, END); /*Arr End*/                                            /* uint32  | size   1 */                                                          \
+#define _0F_09_ENCODE_MEMOS_DUO_GUARDM(buf_out, type1_ptr, type1_len, format1_ptr, format1_len, data1_ptr, data1_len, type2_ptr, type2_len, format2_ptr, format2_len, data2_ptr, data2_len, n, m) \
+    {                                                                                                                                                                                             \
+        ENCODE_FIELDS(buf_out, ARRAY, MEMOS); /*Arr Start*/                                           /* uint32  | size   1 */                                                                    \
+        ENCODE_FIELDS(buf_out, OBJECT, MEMO); /*Obj start*/                                           /* uint32  | size   1 */                                                                    \
+        _07_XX_ENCODE_STI_VL_COMMON_GUARDM(buf_out, type1_ptr, type1_len, MEMO_TYPE, n, m);           /* STI_VL  | size   type_len + (type_len <= 192 ? 2 : 3)*/                                  \
+        _07_XX_ENCODE_STI_VL_COMMON_GUARDM(buf_out, data1_ptr, data1_len, MEMO_DATA, n, m + 1);       /* STI_VL  | size   data_len + (data_len <= 192 ? 2 : 3)*/                                  \
+        _07_XX_ENCODE_STI_VL_COMMON_GUARDM(buf_out, format1_ptr, format1_len, MEMO_FORMAT, n, m + 2); /* STI_VL  | size   format_len + (format_len <= 192 ? 2 : 3)*/                              \
+        ENCODE_FIELDS(buf_out, OBJECT, END); /*Obj end*/                                              /* uint32  | size   1 */                                                                    \
+        ENCODE_FIELDS(buf_out, OBJECT, MEMO); /*Obj start*/                                           /* uint32  | size   1 */                                                                    \
+        _07_XX_ENCODE_STI_VL_COMMON_GUARDM(buf_out, type2_ptr, type2_len, MEMO_TYPE, n, m + 3);       /* STI_VL  | size   type_len + (type_len <= 192 ? 2 : 3)*/                                  \
+        _07_XX_ENCODE_STI_VL_COMMON_GUARDM(buf_out, data2_ptr, data2_len, MEMO_DATA, n, m + 4);       /* STI_VL  | size   data_len + (data_len <= 192 ? 2 : 3)*/                                  \
+        _07_XX_ENCODE_STI_VL_COMMON_GUARDM(buf_out, format2_ptr, format2_len, MEMO_FORMAT, n, m + 5); /* STI_VL  | size   format_len + (format_len <= 192 ? 2 : 3)*/                              \
+        ENCODE_FIELDS(buf_out, OBJECT, END); /*Obj end*/                                              /* uint32  | size   1 */                                                                    \
+        ENCODE_FIELDS(buf_out, ARRAY, END); /*Arr End*/                                               /* uint32  | size   1 */                                                                    \
     }
 
 /////////// Guarded hookmacro.h duplicates. ///////////
@@ -298,23 +295,23 @@ const uint8_t evr_currency[20] = GET_TOKEN_CURRENCY(EVR_TOKEN);
 
 #define PREPARE_PAYMENT_SIMPLE_MEMOS_SINGLE_SIZE(type_len, format_len, data_len) \
     ((type_len + (type_len <= 192 ? 2 : 3) + format_len + (format_len <= 192 ? 2 : 3) + data_len + (data_len <= 192 ? 2 : 3)) + 237 + 4)
-#define PREPARE_PAYMENT_SIMPLE_MEMOS_SINGLE(buf_out_master, drops_amount_raw, drops_fee_raw, to_address, type, type_len, format, format_len, data, data_len) \
-    {                                                                                                                                                        \
-        uint8_t *buf_out = buf_out_master;                                                                                                                   \
-        POPULATE_PAYMENT_SIMPLE_COMMON(buf_out, drops_amount_raw, drops_fee_raw, to_address);                                                                \
-        _0F_09_ENCODE_MEMOS_SINGLE(buf_out, type, type_len, format, format_len, data, data_len);                                                             \
-        etxn_details((uint32_t)buf_out, 105); /* emitdet | size 105 */                                                                                       \
+#define PREPARE_PAYMENT_SIMPLE_MEMOS_SINGLE_M(buf_out_master, drops_amount_raw, drops_fee_raw, to_address, type, type_len, format, format_len, data, data_len, m) \
+    {                                                                                                                                                             \
+        uint8_t *buf_out = buf_out_master;                                                                                                                        \
+        POPULATE_PAYMENT_SIMPLE_COMMON(buf_out, drops_amount_raw, drops_fee_raw, to_address);                                                                     \
+        _0F_09_ENCODE_MEMOS_SINGLE_GUARDM(buf_out, type, type_len, format, format_len, data, data_len, 1, m);                                                     \
+        etxn_details((uint32_t)buf_out, 105); /* emitdet | size 105 */                                                                                            \
     }
 
 #define PREPARE_PAYMENT_SIMPLE_MEMOS_DUO_SIZE(type1_len, format1_len, data1_len, type2_len, format2_len, data2_len)                   \
     ((type2_len + (type2_len <= 192 ? 2 : 3) + format2_len + (format2_len <= 192 ? 2 : 3) + data2_len + (data2_len <= 192 ? 2 : 3)) + \
      (type1_len + (type1_len <= 192 ? 2 : 3) + format1_len + (format1_len <= 192 ? 2 : 3) + data1_len + (data1_len <= 192 ? 2 : 3)) + 237 + 6)
-#define PREPARE_PAYMENT_SIMPLE_MEMOS_DUO(buf_out_master, drops_amount_raw, drops_fee_raw, to_address, type1, type1_len, format1, format1_len, data1, data1_len, type2, type2_len, format2, format2_len, data2, data2_len) \
-    {                                                                                                                                                                                                                     \
-        uint8_t *buf_out = buf_out_master;                                                                                                                                                                                \
-        POPULATE_PAYMENT_SIMPLE_COMMON(buf_out, drops_amount_raw, drops_fee_raw, to_address);                                                                                                                             \
-        _0F_09_ENCODE_MEMOS_DUO(buf_out, type1, type1_len, format1, format1_len, data1, data1_len, type2, type2_len, format2, format2_len, data2, data2_len);                                                             \
-        etxn_details((uint32_t)buf_out, 105); /* emitdet | size 105 */                                                                                                                                                    \
+#define PREPARE_PAYMENT_SIMPLE_MEMOS_DUO_M(buf_out_master, drops_amount_raw, drops_fee_raw, to_address, type1, type1_len, format1, format1_len, data1, data1_len, type2, type2_len, format2, format2_len, data2, data2_len, m) \
+    {                                                                                                                                                                                                                          \
+        uint8_t *buf_out = buf_out_master;                                                                                                                                                                                     \
+        POPULATE_PAYMENT_SIMPLE_COMMON(buf_out, drops_amount_raw, drops_fee_raw, to_address);                                                                                                                                  \
+        _0F_09_ENCODE_MEMOS_DUO_GUARDM(buf_out, type1, type1_len, format1, format1_len, data1, data1_len, type2, type2_len, format2, format2_len, data2, data2_len, 1, m);                                                     \
+        etxn_details((uint32_t)buf_out, 105); /* emitdet | size 105 */                                                                                                                                                         \
     }
 
 /////////// Macros to prepare a trustline transaction with memos. ///////////
@@ -341,12 +338,12 @@ const uint8_t evr_currency[20] = GET_TOKEN_CURRENCY(EVR_TOKEN);
 
 #define PREPARE_PAYMENT_SIMPLE_TRUSTLINE_MEMOS_SINGLE_SIZE(type_len, format_len, data_len) \
     ((type_len + (type_len <= 192 ? 2 : 3) + format_len + (format_len <= 192 ? 2 : 3) + data_len + (data_len <= 192 ? 2 : 3)) + 276 + 4)
-#define PREPARE_PAYMENT_SIMPLE_TRUSTLINE_MEMOS_SINGLE(buf_out_master, tlamt, drops_fee_raw, to_address, type, type_len, format, format_len, data, data_len) \
-    {                                                                                                                                                       \
-        uint8_t *buf_out = buf_out_master;                                                                                                                  \
-        POPULATE_PAYMENT_SIMPLE_TRUSTLINE_COMMON(buf_out, tlamt, drops_fee_raw, to_address);                                                                \
-        _0F_09_ENCODE_MEMOS_SINGLE(buf_out, type, type_len, format, format_len, data, data_len);                                                            \
-        etxn_details((uint32_t)buf_out, 105); /* emitdet | size 105 */                                                                                      \
+#define PREPARE_PAYMENT_SIMPLE_TRUSTLINE_MEMOS_SINGLE_M(buf_out_master, tlamt, drops_fee_raw, to_address, type, type_len, format, format_len, data, data_len, m) \
+    {                                                                                                                                                            \
+        uint8_t *buf_out = buf_out_master;                                                                                                                       \
+        POPULATE_PAYMENT_SIMPLE_TRUSTLINE_COMMON(buf_out, tlamt, drops_fee_raw, to_address);                                                                     \
+        _0F_09_ENCODE_MEMOS_SINGLE_GUARDM(buf_out, type, type_len, format, format_len, data, data_len, 1, m);                                                    \
+        etxn_details((uint32_t)buf_out, 105); /* emitdet | size 105 */                                                                                           \
     }
 
 /////////// Macros to prepare a check with memos. ///////////
@@ -408,47 +405,47 @@ const uint8_t evr_currency[20] = GET_TOKEN_CURRENCY(EVR_TOKEN);
 
 #define PREPARE_PAYMENT_REDEEM_SIZE(redeem_data_len, origin_data_len) \
     (PREPARE_PAYMENT_SIMPLE_MEMOS_DUO_SIZE(9, 6, redeem_data_len, 15, 3, origin_data_len))
-#define PREPARE_PAYMENT_REDEEM(buf_out_master, drops_amount_raw, drops_fee_raw, to_address, redeem_data, redeem_data_len, origin_data, origin_data_len)                                                                           \
-    {                                                                                                                                                                                                                             \
-        PREPARE_PAYMENT_SIMPLE_MEMOS_DUO(buf_out_master, drops_amount_raw, drops_fee_raw, to_address, REDEEM, 9, FORMAT_BASE64, 6, redeem_data, redeem_data_len, REDEEM_ORIGIN, 15, FORMAT_HEX, 3, origin_data, origin_data_len); \
+#define PREPARE_PAYMENT_REDEEM_M(buf_out_master, drops_amount_raw, drops_fee_raw, to_address, redeem_data, redeem_data_len, origin_data, origin_data_len, m)                                                                           \
+    {                                                                                                                                                                                                                                  \
+        PREPARE_PAYMENT_SIMPLE_MEMOS_DUO_M(buf_out_master, drops_amount_raw, drops_fee_raw, to_address, REDEEM, 9, FORMAT_BASE64, 6, redeem_data, redeem_data_len, REDEEM_ORIGIN, 15, FORMAT_HEX, 3, origin_data, origin_data_len, m); \
     }
 
 #define PREPARE_PAYMENT_REDEEM_RESP_SIZE(redeem_resp_len, redeem_ref_len, is_success) \
     (PREPARE_PAYMENT_SIMPLE_MEMOS_DUO_SIZE((is_success ? 16 : 14), (is_success ? 6 : 9), redeem_resp_len, 12, 3, redeem_ref_len))
-#define PREPARE_PAYMENT_REDEEM_RESP(buf_out_master, drops_amount_raw, drops_fee_raw, to_address, redeem_resp_ptr, redeem_resp_len, redeem_ref_ptr, redeem_ref_len, is_success)                                                                    \
-    {                                                                                                                                                                                                                                             \
-        if (is_success)                                                                                                                                                                                                                           \
-        {                                                                                                                                                                                                                                         \
-            PREPARE_PAYMENT_SIMPLE_MEMOS_DUO(buf_out_master, drops_amount_raw, drops_fee_raw, to_address, REDEEM_SUCCESS, 16, FORMAT_BASE64, 6, redeem_resp_ptr, redeem_resp_len, REDEEM_REF, 12, FORMAT_HEX, 3, redeem_ref_ptr, redeem_ref_len); \
-        }                                                                                                                                                                                                                                         \
-        else                                                                                                                                                                                                                                      \
-        {                                                                                                                                                                                                                                         \
-            PREPARE_PAYMENT_SIMPLE_MEMOS_DUO(buf_out_master, drops_amount_raw, drops_fee_raw, to_address, REDEEM_ERROR, 14, FORMAT_JSON, 9, redeem_resp_ptr, redeem_resp_len, REDEEM_REF, 12, FORMAT_HEX, 3, redeem_ref_ptr, redeem_ref_len);     \
-        }                                                                                                                                                                                                                                         \
+#define PREPARE_PAYMENT_REDEEM_RESP_M(buf_out_master, drops_amount_raw, drops_fee_raw, to_address, redeem_resp_ptr, redeem_resp_len, redeem_ref_ptr, redeem_ref_len, is_success, m)                                                                    \
+    {                                                                                                                                                                                                                                                  \
+        if (is_success)                                                                                                                                                                                                                                \
+        {                                                                                                                                                                                                                                              \
+            PREPARE_PAYMENT_SIMPLE_MEMOS_DUO_M(buf_out_master, drops_amount_raw, drops_fee_raw, to_address, REDEEM_SUCCESS, 16, FORMAT_BASE64, 6, redeem_resp_ptr, redeem_resp_len, REDEEM_REF, 12, FORMAT_HEX, 3, redeem_ref_ptr, redeem_ref_len, m); \
+        }                                                                                                                                                                                                                                              \
+        else                                                                                                                                                                                                                                           \
+        {                                                                                                                                                                                                                                              \
+            PREPARE_PAYMENT_SIMPLE_MEMOS_DUO_M(buf_out_master, drops_amount_raw, drops_fee_raw, to_address, REDEEM_ERROR, 14, FORMAT_JSON, 9, redeem_resp_ptr, redeem_resp_len, REDEEM_REF, 12, FORMAT_HEX, 3, redeem_ref_ptr, redeem_ref_len, m);     \
+        }                                                                                                                                                                                                                                              \
     }
 
 #define PREPARE_PAYMENT_REWARD_SIZE \
     (PREPARE_PAYMENT_SIMPLE_TRUSTLINE_MEMOS_SINGLE_SIZE(9, 0, 0))
-#define PREPARE_PAYMENT_REWARD(buf_out_master, tlamt, drops_fee_raw, to_address)                                                                \
-    {                                                                                                                                           \
-        PREPARE_PAYMENT_SIMPLE_TRUSTLINE_MEMOS_SINGLE(buf_out_master, tlamt, drops_fee_raw, to_address, REWARD, 9, empty_ptr, 0, empty_ptr, 0); \
+#define PREPARE_PAYMENT_REWARD_M(buf_out_master, tlamt, drops_fee_raw, to_address, m)                                                                \
+    {                                                                                                                                                \
+        PREPARE_PAYMENT_SIMPLE_TRUSTLINE_MEMOS_SINGLE_M(buf_out_master, tlamt, drops_fee_raw, to_address, REWARD, 9, empty_ptr, 0, empty_ptr, 0, m); \
     }
 
 #define PREPARE_PAYMENT_REFUND_SUCCESS_SIZE \
     (PREPARE_PAYMENT_SIMPLE_TRUSTLINE_MEMOS_SINGLE_SIZE(16, 3, 64))
-#define PREPARE_PAYMENT_REFUND_SUCCESS(buf_out_master, tlamt, drops_fee_raw, to_address, refund_ptr, redeem_ptr)                                           \
-    {                                                                                                                                                      \
-        uint8_t memo_data[64];                                                                                                                             \
-        COPY_BUF_GUARDM(memo_data, 0, refund_ptr, 0, 32, 1, 4);                                                                                            \
-        COPY_BUF_GUARDM(memo_data, 32, redeem_ptr, 0, 32, 1, 5);                                                                                           \
-        PREPARE_PAYMENT_SIMPLE_TRUSTLINE_MEMOS_SINGLE(buf_out_master, tlamt, drops_fee_raw, to_address, REFUND_SUCCESS, 16, FORMAT_HEX, 3, memo_data, 64); \
+#define PREPARE_PAYMENT_REFUND_SUCCESS_M(buf_out_master, tlamt, drops_fee_raw, to_address, refund_ptr, redeem_ptr, m)                                           \
+    {                                                                                                                                                           \
+        uint8_t memo_data[64];                                                                                                                                  \
+        COPY_BUF_GUARDM(memo_data, 0, refund_ptr, 0, 32, 1, 4);                                                                                                 \
+        COPY_BUF_GUARDM(memo_data, 32, redeem_ptr, 0, 32, 1, 5);                                                                                                \
+        PREPARE_PAYMENT_SIMPLE_TRUSTLINE_MEMOS_SINGLE_M(buf_out_master, tlamt, drops_fee_raw, to_address, REFUND_SUCCESS, 16, FORMAT_HEX, 3, memo_data, 64, m); \
     }
 
 #define PREPARE_PAYMENT_REFUND_ERROR_SIZE \
     (PREPARE_PAYMENT_SIMPLE_MEMOS_SINGLE_SIZE(14, 3, 32))
-#define PREPARE_PAYMENT_REFUND_ERROR(buf_out_master, drops_amount_raw, drops_fee_raw, to_address, refund_ptr)                                              \
-    {                                                                                                                                                      \
-        PREPARE_PAYMENT_SIMPLE_MEMOS_SINGLE(buf_out_master, drops_amount_raw, drops_fee_raw, to_address, REFUND_ERROR, 14, FORMAT_HEX, 3, refund_ptr, 32); \
+#define PREPARE_PAYMENT_REFUND_ERROR_M(buf_out_master, drops_amount_raw, drops_fee_raw, to_address, refund_ptr, m)                                              \
+    {                                                                                                                                                           \
+        PREPARE_PAYMENT_SIMPLE_MEMOS_SINGLE_M(buf_out_master, drops_amount_raw, drops_fee_raw, to_address, REFUND_ERROR, 14, FORMAT_HEX, 3, refund_ptr, 32, m); \
     }
 
 #define PREPARE_AUDIT_CHECK_SIZE \
@@ -582,27 +579,27 @@ const uint8_t evr_currency[20] = GET_TOKEN_CURRENCY(EVR_TOKEN);
         IS_HOST_ACTIVE_MOMENT_IDX_SIZE_GIVEN(is_active, host_addr_buf, cur_moment_start_idx, conf_moment_size);                        \
     }
 
-#define EMIT_AUDIT_CHECK_GUARD(cur_moment_start_idx, moment_seed_buf, min_redeem, host_addr, host_addr_buf, to_addr, n) \
-    {                                                                                                                   \
-        uint8_t *host_token_ptr = &host_addr_buf[HOST_TOKEN_OFFSET];                                                    \
-        trace(SBUF("Hosting token"), host_token_ptr, 3, 1);                                                             \
-        /* If host is already assigned for audit within this moment we won't reward again. */                           \
-        if (UINT64_FROM_BUF(&host_addr_buf[HOST_AUDIT_IDX_OFFSET]) == cur_moment_start_idx)                             \
-            rollback(SBUF("Evernode: Picked host is already assigned for audit within this moment."), 1);               \
-        int64_t fee = etxn_fee_base(PREPARE_AUDIT_CHECK_SIZE);                                                          \
-        int64_t token_limit = float_set(0, min_redeem);                                                                 \
-        uint8_t amt_out[AMOUNT_BUF_SIZE];                                                                               \
-        SET_AMOUNT_OUT_GUARDM(amt_out, host_token_ptr, host_addr, token_limit, n, 1);                                   \
-        /* Finally create the outgoing txn. */                                                                          \
-        uint8_t txn_out[PREPARE_AUDIT_CHECK_SIZE];                                                                      \
-        PREPARE_AUDIT_CHECK_GUARDM(txn_out, amt_out, fee, to_addr, n, 2);                                               \
-        uint8_t emithash[HASH_SIZE];                                                                                    \
-        if (emit(SBUF(emithash), SBUF(txn_out)) < 0)                                                                    \
-            rollback(SBUF("Evernode: Emitting hosting token check failed."), 1);                                        \
-        trace(SBUF("emit hash: "), SBUF(emithash), 1);                                                                  \
-        /* Update the host's audit assigned state. */                                                                   \
-        COPY_BUF_GUARDM(host_addr_buf, HOST_AUDIT_IDX_OFFSET, moment_seed_buf, 0, 8, n, 13);                            \
-        COPY_BUF_GUARDM(host_addr_buf, HOST_AUDITOR_OFFSET, to_addr, 0, 20, n, 14);                                     \
+#define EMIT_AUDIT_CHECK_GUARDM(cur_moment_start_idx, moment_seed_buf, min_redeem, host_addr, host_addr_buf, to_addr, n, m) \
+    {                                                                                                                       \
+        uint8_t *host_token_ptr = &host_addr_buf[HOST_TOKEN_OFFSET];                                                        \
+        trace(SBUF("Hosting token"), host_token_ptr, 3, 1);                                                                 \
+        /* If host is already assigned for audit within this moment we won't reward again. */                               \
+        if (UINT64_FROM_BUF(&host_addr_buf[HOST_AUDIT_IDX_OFFSET]) == cur_moment_start_idx)                                 \
+            rollback(SBUF("Evernode: Picked host is already assigned for audit within this moment."), 1);                   \
+        int64_t fee = etxn_fee_base(PREPARE_AUDIT_CHECK_SIZE);                                                              \
+        int64_t token_limit = float_set(0, min_redeem);                                                                     \
+        uint8_t amt_out[AMOUNT_BUF_SIZE];                                                                                   \
+        SET_AMOUNT_OUT_GUARDM(amt_out, host_token_ptr, host_addr, token_limit, n, m);                                       \
+        /* Finally create the outgoing txn. */                                                                              \
+        uint8_t txn_out[PREPARE_AUDIT_CHECK_SIZE];                                                                          \
+        PREPARE_AUDIT_CHECK_GUARDM(txn_out, amt_out, fee, to_addr, n, m + 1);                                               \
+        uint8_t emithash[HASH_SIZE];                                                                                        \
+        if (emit(SBUF(emithash), SBUF(txn_out)) < 0)                                                                        \
+            rollback(SBUF("Evernode: Emitting hosting token check failed."), 1);                                            \
+        trace(SBUF("emit hash: "), SBUF(emithash), 1);                                                                      \
+        /* Update the host's audit assigned state. */                                                                       \
+        COPY_BUF_GUARDM(host_addr_buf, HOST_AUDIT_IDX_OFFSET, moment_seed_buf, 0, 8, n, m + 5);                             \
+        COPY_BUF_GUARDM(host_addr_buf, HOST_AUDITOR_OFFSET, to_addr, 0, 20, n, m + 6);                                      \
     }
 
 #endif

--- a/src/evernode.h
+++ b/src/evernode.h
@@ -73,6 +73,13 @@ const uint8_t evr_currency[20] = GET_TOKEN_CURRENCY(EVR_TOKEN);
         }                                                          \
     }
 
+#define STR_TO_UINT(number, str_ptr, str_len)             \
+    {                                                     \
+        number = 0;                                       \
+        for (int i = 0; GUARD(str_len), i < str_len; i++) \
+            number = number * 10 + (int)str_ptr[i] - '0'; \
+    }
+
 #define IS_BUF_EMPTY(is_empty, buf)                           \
     is_empty = 1;                                             \
     for (int i = 0; GUARD(sizeof(buf)), i < sizeof(buf); ++i) \
@@ -172,6 +179,12 @@ const uint8_t evr_currency[20] = GET_TOKEN_CURRENCY(EVR_TOKEN);
 
 #define COPY_BUF(lhsbuf, lhsbuf_spos, rhsbuf, rhsbuf_spos, len) \
     COPY_BUF_GUARDM(lhsbuf, lhsbuf_spos, rhsbuf, rhsbuf_spos, len, 1, 1);
+
+#define CLEAR_BUF(buf, buf_spos, len)             \
+    {                                             \
+        for (int i = 0; GUARD(len), i < len; ++i) \
+            buf[buf_spos + i] = 0;                \
+    }
 
 // If host count state does not exist, set host count to 0.
 #define GET_HOST_COUNT(host_count_buf, host_count)                             \

--- a/src/statekeys.h
+++ b/src/statekeys.h
@@ -63,6 +63,8 @@ const uint8_t CONF_REWARD[32] = {'E', 'V', 'R', 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 const uint8_t CONF_MAX_REWARD[32] = {'E', 'V', 'R', 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7};
 // No. of maximum hosts that can be audited by a audit per moment.
 const uint8_t CONF_MAX_AUDIT[32] = {'E', 'V', 'R', 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8};
+// Moment frequency which host should keep recharging the hook (which used to track host aliveness).
+const uint8_t CONF_HOST_HEARTBEAT_FREQ[32] = {'E', 'V', 'R', 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9};
 
 #define STATE_KEY(buf, prefix, key, key_len)                      \
     buf[0] = 'E';                                                 \


### PR DESCRIPTION
- Introduced host recharge transactions
- Check host activeness using last recharged moment
- Introduced last host heartbeat moment frequency
- Keep locked host token amount for redeem requests
- Keep minimum required host token amount only (locked_amount + MIN_REDEEM * (CONF_HOST_HEARTBEAT_FREQ + 1))
- Introduced line guards for hook transactions
- Modified host metadata in host address state
- Refactored code